### PR TITLE
Added Lambda function to stop EC2 instances and updated DynamoDB table

### DIFF
--- a/EC2-Autostop/CloudWatchAutoAlarms.yaml
+++ b/EC2-Autostop/CloudWatchAutoAlarms.yaml
@@ -57,11 +57,83 @@ Resources:
           ALARM_IDENTIFIER_PREFIX: !Ref AlarmIdentifierPrefix
           CLOUDWATCH_APPEND_DIMENSIONS: 'InstanceId, ImageId, InstanceType'
           AWS_ACCOUNT_ID: !Ref AWS::AccountId
+          LAMBDA_AUTO_STOP_ARN: !GetAtt LambdaAutoStopper.Arn
 
           ALARM_LAMBDA_ERROR_THRESHOLD: 0
           ALARM_LAMBDA_THROTTLE_THRESHOLD: 0
 
           DEFAULT_ALARM_SNS_TOPIC_ARN: !If [ConfigureAlarmNotifications, !Ref AlarmNotificationARN, !Ref "AWS::NoValue"]
+
+  LambdaAutoStopper:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: "AutoStopEC2"
+      Handler: auto_stop_ec2.lambda_handler
+      Runtime: python3.8
+      Role:  !GetAtt LambdaAutoStopperRole.Arn
+      MemorySize: !Ref Memory
+      Timeout: 600
+      Code:
+        S3Bucket: !Ref S3DeploymentBucket
+        S3Key: !Ref S3DeploymentKey
+      Environment:
+        Variables:
+          AWS_ACCOUNT_ID: !Ref AWS::AccountId
+          DYNAMODB_TABLE_NAME: "REPLACE_ME"
+      Tags:
+        - Key: "EC2_AUTO_STOP"
+          Value: "true"
+
+  LambdaAutoStopperRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "lambda.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: "LambdaEc2AutoStopperPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogGroups
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
+              - Effect: Allow
+                Action:
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*"
+              - Effect: "Allow"
+                Action:
+                  - "dynamodb:GetItem"
+                  - "dynamodb:Scan"
+                  - "dynamodb:Query"
+                  - "dynamodb:PutItem"
+                  - "dynamodb:UpdateItem"
+                  - "dynamodb:DeleteItem"
+                Resource: "*"
+              - Effect: "Allow"
+                Action:
+                  - "ec2:StopInstances"
+                Resource: "*"
+
+  LambdaAutoStopperInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: "lambda:InvokeFunction"
+      FunctionName: !GetAtt LambdaAutoStopper.Arn
+      Principal: "lambda.alarms.cloudwatch.amazonaws.com"
 
   CloudWatchAutoAlarmLambdaRole:
     Type: AWS::IAM::Role

--- a/EC2-Autostop/README.md
+++ b/EC2-Autostop/README.md
@@ -68,6 +68,8 @@ The following list provides a description of the setting along with the environm
     * You can define an Amazon Simple Notification Service (Amazon SNS) topic that the Lambda function will specify as the notification target for created alarms. You provide the Amazon SNS Topic Amazon Resource Name (ARN) with the **AlarmNotificationARN** parameter when you deploy the CloudWatchAutoAlarms.yaml CloudFormation template.  If you leave the **AlarmNotificationARN** parameter value blank, then this environment variable is not set and created alarms won't use notifications.
 * **ALARM_IDENTIFIER_PREFIX**:  AutoAlarm
     * The prefix name that is added to the beginning of each CloudWatch alarm created by the solution.  (e.g. For "AutoAlarm":  (e.g. AutoAlarm-i-00e4f327736cb077f-CPUUtilization-GreaterThanThreshold-80-5m))  You should update this variable via the **AlarmIdentifierPrefix** in the [CloudWatchAutoAlarms.yaml](./CloudWatchAutoAlarms.yaml) CloudFormation template so that the IAM policy is updated to align with your custom name. 
+* **DYNAMODB_TABLE_NAME**:  REPLACE_ME
+    * This is an environment variable for the AutoStopEC2 lambda function. This is used to store the instance state of the EC2 instances.
 
 You can update the thresholds for the default alarms by updating the following environment variables:
 

--- a/EC2-Autostop/src/auto_stop_ec2.py
+++ b/EC2-Autostop/src/auto_stop_ec2.py
@@ -1,0 +1,66 @@
+import logging
+import os
+import re
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    logger.info('event received: {}'.format(event))
+
+    alarm_arn = event.get("alarmArn")
+
+    if not alarm_arn:
+        logger.error("No alarmArn in event")
+        return {
+            'statusCode': 400,
+            'body': 'No alarmArn in event'
+        }
+
+    match = re.search(r'i-[0-9a-f]+', alarm_arn)
+    instance_id = match.group()
+
+    if not instance_id:
+        logger.error(f"Could not find instance id in alarmArn {alarm_arn}")
+        return {
+            'statusCode': 400,
+            'body': 'Could not find instance id in alarmArn'
+        }
+
+    logger.info(f"The following instance is in alarm & needs to be shut down: {instance_id}")
+
+    # find the dynamodb record
+    dynamodb_table_name = os.environ['DYNAMODB_TABLE_NAME']
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table(dynamodb_table_name)
+
+    logger.info(f"Searching for instance {instance_id} in dynamoddb table {dynamodb_table_name}")
+    response = table.get_item(Key={'id': instance_id})
+
+    if 'Item' not in response:
+        logger.error(f"Instance {instance_id} not found in dynamodb table")
+    else:
+        logger.info(f"Found instance {instance_id} in dynamodb table")
+        logger.info(f"Setting status to STOPPED")
+        table.update_item(
+            Key={'id': instance_id},
+            UpdateExpression='SET #status = :val1',
+            ExpressionAttributeNames={'#status': 'status'},
+            ExpressionAttributeValues={
+                ':val1': 'STOPPED'
+            }
+        )
+        logger.info(f"Set status to STOPPED in dynamodb table")
+
+    # stop the instance itself
+    ec2 = boto3.client('ec2')
+    logger.info(f"Stopping instance {instance_id}")
+    ec2.stop_instances(InstanceIds=[instance_id])
+    logger.info(f"Stopped instance {instance_id}")
+
+    return {
+        'statusCode': 200,
+        'body': f'Stopped instance {instance_id}'
+    }


### PR DESCRIPTION
Hello all, here are the changes necessary for the cloudwatch alarms to update your dynamodb table with the correct EC2 instance status.

**Follow these steps to upgrade your environment:**
1. Update `DYNAMODB_TABLE_NAME` environment variable in `CloudWatchAutoAlarms.yaml` for your environment.
2. Change any other security settings for the lambda's new role specific to your environment.
3. Follow steps 6, 7 and 8 (replace `create-stack` with `update-stack`) from the README for the this new code to take effect.