### PR TITLE
Add support for managing DynamoDB in different environments

### DIFF
--- a/EC2-Autostop/CloudWatchAutoAlarms.yaml
+++ b/EC2-Autostop/CloudWatchAutoAlarms.yaml
@@ -26,6 +26,18 @@ Parameters:
     Description: Enter the prefix that should be added to the beginning of each alarm created by the solution, (e.g. AutoAlarm-i-00e4f327736cb077f-CPUUtilization-GreaterThanThreshold-80-5m)
     Type: String
     Default: AutoAlarm
+  ProductionDynamoDBTableName:
+    Description: Enter the name of the DynamoDB table for production
+    Type: String
+  ProductionDynamoDbAccessRoleArn:
+    Description: Enter the ARN of the role that the AutoStopEC2 lambda can assume to access the production DynamoDB table
+    Type: String
+  DevelopmentDynamoDBTableName:
+    Description: Enter the name of the DynamoDB table for development
+    Type: String
+  DevelopmentDynamoDbAccessRoleArn:
+    Description: Enter the ARN of the role that the AutoStopEC2 lambda can assume to access the development DynamoDB table
+    Type: String
 
 
 Conditions:
@@ -79,7 +91,10 @@ Resources:
       Environment:
         Variables:
           AWS_ACCOUNT_ID: !Ref AWS::AccountId
-          DYNAMODB_TABLE_NAME: "REPLACE_ME"
+          PROD_DYNAMODB_ROLE_ARN: !Ref ProductionDynamoDbAccessRoleArn
+          DEV_DYNAMODB_ROLE_ARN: !Ref DevelopmentDynamoDbAccessRoleArn
+          PROD_DYNAMODB_TABLE: !Ref ProductionDynamoDBTableName
+          DEV_DYNAMODB_TABLE: !Ref DevelopmentDynamoDBTableName
       Tags:
         - Key: "EC2_AUTO_STOP"
           Value: "true"
@@ -116,17 +131,24 @@ Resources:
                 Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*"
               - Effect: "Allow"
                 Action:
-                  - "dynamodb:GetItem"
-                  - "dynamodb:Scan"
-                  - "dynamodb:Query"
-                  - "dynamodb:PutItem"
-                  - "dynamodb:UpdateItem"
-                  - "dynamodb:DeleteItem"
-                Resource: "*"
-              - Effect: "Allow"
-                Action:
                   - "ec2:StopInstances"
                 Resource: "*"
+        - PolicyName: "AssumeCrossAccountRoleDev"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "sts:AssumeRole"
+                Resource: !Ref DevelopmentDynamoDbAccessRoleArn
+        - PolicyName: "AssumeCrossAccountRoleProd"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "sts:AssumeRole"
+                Resource: !Ref ProductionDynamoDbAccessRoleArn
 
   LambdaAutoStopperInvokePermission:
     Type: AWS::Lambda::Permission

--- a/EC2-Autostop/CloudWatchAutoAlarmsDynamoAccess.yml
+++ b/EC2-Autostop/CloudWatchAutoAlarmsDynamoAccess.yml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Automatically Create DynamoDb Role for Lambda function to assume
+Parameters:
+  AutoStopLambdaFunctionRoleArn:
+    Description: Enter the ARN of the role applied to the AutoStopEC2 Lambda function
+    Type: String
+  DynamoDBTableArn:
+    Description: Enter the ARN of the DynamoDB table that the AutoStop Lambda function will access
+    Type: String
+
+Resources:
+  CrossAccountRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref AutoStopLambdaFunctionRoleArn
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: "DynamoDBAccessPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "dynamodb:GetItem"
+                  - "dynamodb:Scan"
+                  - "dynamodb:Query"
+                  - "dynamodb:PutItem"
+                  - "dynamodb:UpdateItem"
+                  - "dynamodb:DeleteItem"
+                Resource: !Sub "${DynamoDBTableArn}"


### PR DESCRIPTION
Hello all, here are the changes necessary for the cloudwatch alarms to update your dynamodb table (in separate accounts) with the correct EC2 instance status.

Follow these steps to upgrade your environment:

1. Deploy the new `CloudWatchAutoAlarmsDynamoAccess.yml` CloudFormation file to your account(s) that contain the DynamoDb tables. (If they exist in the same account, just deploy it twice in the same account with the correct table names for each db, otherwise deploy it once per account containing the dynamodb table).
**1a.**  You can use `arn:aws:iam::REPLACE_ME_WITH_LAMBDA_FUNCTION_ACCOUNT_ID:root` as the AutoStopLambdaFunctionRoleArn for now (we'll replace it later).
![image](https://github.com/hms-dbmi/service-workbench-automation-security-scripts/assets/15789820/4714fcb5-8c61-4129-934b-2d18353bde09)

2. Note down the 2 new role arns that were created by CloudFormation for the new AutoStopEC2 lambda to assume as they are needed to update the `amazon-cloudwatch-auto-alarms` stack.
3. Follow steps 6, 7 and 8 (replace create-stack with update-stack) from the README for the this new code to take effect.
**3a.** You should now have an AutoStopEC2 lambda function that will stop the ec2 instances and update dynamodb.
**Example of new parameters for CloudWatchAutoAlarms.yaml:**
![image](https://github.com/hms-dbmi/service-workbench-automation-security-scripts/assets/15789820/88be7d0f-321e-4d40-aaf1-c69730dd586f)

4. Note down the role arn attached to the AutoStopEC2 lambda function.
5. Update the existing stacks from step 1 with the AutoStopEC2 lambda function role.
**Example of final parameters for CloudWatchAutoAlarmsDynamoAccess.yml**
![image](https://github.com/hms-dbmi/service-workbench-automation-security-scripts/assets/15789820/01caad9f-52db-420b-8ecf-cf8e6abea5d5)

7. Test it out.





