### PR TITLE
Modified cloudformation and lambda code to operate with disconnected …

### DIFF
--- a/EC2-Autostop/CloudWatchAutoAlarms.yaml
+++ b/EC2-Autostop/CloudWatchAutoAlarms.yaml
@@ -26,17 +26,11 @@ Parameters:
     Description: Enter the prefix that should be added to the beginning of each alarm created by the solution, (e.g. AutoAlarm-i-00e4f327736cb077f-CPUUtilization-GreaterThanThreshold-80-5m)
     Type: String
     Default: AutoAlarm
-  ProductionDynamoDBTableName:
+  DynamoDBTableName:
     Description: Enter the name of the DynamoDB table for production
     Type: String
-  ProductionDynamoDbAccessRoleArn:
+  DynamoDbAccessRoleArn:
     Description: Enter the ARN of the role that the AutoStopEC2 lambda can assume to access the production DynamoDB table
-    Type: String
-  DevelopmentDynamoDBTableName:
-    Description: Enter the name of the DynamoDB table for development
-    Type: String
-  DevelopmentDynamoDbAccessRoleArn:
-    Description: Enter the ARN of the role that the AutoStopEC2 lambda can assume to access the development DynamoDB table
     Type: String
 
 
@@ -91,10 +85,8 @@ Resources:
       Environment:
         Variables:
           AWS_ACCOUNT_ID: !Ref AWS::AccountId
-          PROD_DYNAMODB_ROLE_ARN: !Ref ProductionDynamoDbAccessRoleArn
-          DEV_DYNAMODB_ROLE_ARN: !Ref DevelopmentDynamoDbAccessRoleArn
-          PROD_DYNAMODB_TABLE: !Ref ProductionDynamoDBTableName
-          DEV_DYNAMODB_TABLE: !Ref DevelopmentDynamoDBTableName
+          DYNAMODB_ROLE_ARN: !Ref DynamoDbAccessRoleArn
+          DYNAMODB_TABLE: !Ref DynamoDBTableName
       Tags:
         - Key: "EC2_AUTO_STOP"
           Value: "true"
@@ -133,22 +125,14 @@ Resources:
                 Action:
                   - "ec2:StopInstances"
                 Resource: "*"
-        - PolicyName: "AssumeCrossAccountRoleDev"
+        - PolicyName: "AssumeCrossAccountRole"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: "Allow"
                 Action:
                   - "sts:AssumeRole"
-                Resource: !Ref DevelopmentDynamoDbAccessRoleArn
-        - PolicyName: "AssumeCrossAccountRoleProd"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  - "sts:AssumeRole"
-                Resource: !Ref ProductionDynamoDbAccessRoleArn
+                Resource: !Ref DynamoDbAccessRoleArn
 
   LambdaAutoStopperInvokePermission:
     Type: AWS::Lambda::Permission

--- a/EC2-Autostop/CloudWatchAutoAlarmsDynamoAccess.yml
+++ b/EC2-Autostop/CloudWatchAutoAlarmsDynamoAccess.yml
@@ -1,3 +1,10 @@
+# This CloudFormation template is designed to automate the creation of an IAM role
+# that allows a specific Lambda function to access a DynamoDB table. It defines
+# the parameters needed to specify the ARN of the Lambda function's role and the
+# ARN of the DynamoDB table. The template includes a single resource, an IAM role,
+# that the Lambda function can assume to perform various actions on the specified
+# DynamoDB table.
+
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Automatically Create DynamoDb Role for Lambda function to assume
 Parameters:


### PR DESCRIPTION
dHello all, here are the changes necessary for the cloudwatch alarms to update your dynamodb table (in a separate account) with the correct EC2 instance status.

Follow these steps to upgrade your environment:

1. Deploy the new `CloudWatchAutoAlarmsDynamoAccess.yml` CloudFormation file to your account that contains the DynamoDb table. This is necessary for the Lambda to modify the DynamoDb table since they are in two different accounts.
1a. You can use arn:aws:iam::REPLACE_ME_WITH_LAMBDA_FUNCTION_ACCOUNT_ID:root as the AutoStopLambdaFunctionRoleArn for now (we'll replace it later).
2a. If you already have the AutoStopEc2 lambda function deployed, you can use the ARN of the role that the lambda function is using. This can be found under Configuration -> Permissions in the lambda details page.
2. Note down the new role arn that was created by CloudFormation. The role ARN will be used for the AutoStopEC2 lambda to assume the role in the DynamoDB account  - they are needed to update the amazon-cloudwatch-auto-alarms stack.
3. Follow steps 6, 7 and 8 (replace create-stack with update-stack) from the README for the this new lambda code to take effect.
3a. You should now have an AutoStopEC2 lambda function that will stop the ec2 instances and update dynamodb.
4. Note down the role arn attached to the AutoStopEC2 lambda function.
5. Update the existing stacks from step 1 with the AutoStopEC2 lambda function role to allow the assume role operation.
5a. This is only necessary if you didn't have the role deployed or the role ARN was changed in some scenario.
